### PR TITLE
Logistic Assembling Machines rebooted support

### DIFF
--- a/info.json
+++ b/info.json
@@ -10,6 +10,7 @@
     "dependencies": [
         "base >= 1.0",
         "? SeaBlock >= 0.5.6",
+        "? LogisticAssemblingMachine-rebooted > 1.0.0",
         "! Braver_New_World"
     ]
 }

--- a/scenarios/bnw/control.lua
+++ b/scenarios/bnw/control.lua
@@ -380,6 +380,12 @@ local function setupForce(force, surface, x, y, seablock_enabled)
         chest_inventory.insert{name = "gun-turret", count = 2}
         chest_inventory.insert{name = "firearm-magazine", count = 20}
     end
+
+    local logisticsAssemblerReboot_enabled = game.active_mods["LogisticAssemblingMachine-rebooted"]
+    if (logisticsAssemblerReboot_enabled) then
+        chest_inventory.insert{name = "logistic-assembling-machine", count = 4}
+    end
+
     -- solar panels and accumulators (left side)
     surface.create_entity{name = "solar-panel", position = {x - 11, y - 2}, force = force, raise_built = true}
     surface.create_entity{name = "solar-panel", position = {x - 11, y + 1}, force = force, raise_built = true}


### PR DESCRIPTION
Added support for [Logistic Assembling Machines rebooted](https://mods.factorio.com/mod/LogisticAssemblingMachine-rebooted). If the mod is loaded 4 of the automated machines are added to the starting chest of the scenario.

Added the mod as optional dependency.

I was not sure if you want me to do the changelog/version update or that you will do that upon release